### PR TITLE
init window cache with actual values. Fixes #8

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,17 @@ impl<R: Runtime> Plugin<R> for WindowState {
                     }))
                     .unwrap();
             } else {
-                c.insert(window.label().into(), Default::default());
+                let PhysicalSize { width, height } = window.inner_size().unwrap();
+                let PhysicalPosition { x, y } = window.outer_position().unwrap();
+                c.insert(
+                    window.label().into(),
+                    WindowMetadata {
+                        width,
+                        height,
+                        x,
+                        y,
+                    },
+                );
             }
         }
 


### PR DESCRIPTION
Fixes tauri-apps/plugins-workspace#251 by replacing Default::default() with the actual values via getters.
The fix for tauri-apps/plugins-workspace#253 might conflict with this (or makes it obsolete), but i thought it's still worth to fix this separately until we figure out how to resolve tauri-apps/plugins-workspace#253.