### PR TITLE
switched order of `set_size` and `set_position`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,7 +177,7 @@ impl Builder {
   /// Sets a list of windows that shouldn't be tracked and managed by this plugin
   /// for example splash screen widnows.
   pub fn with_denylist(mut self, denylist: &[&str]) -> Self {
-    self.denylist = denylist.into_iter().map(|l| l.to_string()).collect();
+    self.denylist = denylist.iter().map(|l| l.to_string()).collect();
     self
   }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,11 @@ impl<R: Runtime> WindowExt for Window<R> {
     if let Some(state) = c.get(self.label()) {
       self.set_decorations(state.decorated)?;
 
+      self.set_size(Size::Physical(PhysicalSize {
+        width: state.width,
+        height: state.height,
+      }))?;
+      
       let mut pos: Option<(i32, i32)> = None;
       for m in self.available_monitors()? {
         if m.name().map(ToString::to_string).unwrap_or_default() == state.monitor {
@@ -100,10 +105,6 @@ impl<R: Runtime> WindowExt for Window<R> {
       };
       self.set_position(Position::Physical(PhysicalPosition { x, y }))?;
 
-      self.set_size(Size::Physical(PhysicalSize {
-        width: state.width,
-        height: state.height,
-      }))?;
       if state.maximized {
         self.maximize()?;
       }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,6 @@ impl<R: Runtime> WindowExt for Window<R> {
         width: state.width,
         height: state.height,
       }))?;
-      
       let mut pos: Option<(i32, i32)> = None;
       for m in self.available_monitors()? {
         if m.name().map(ToString::to_string).unwrap_or_default() == state.monitor {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,7 @@ impl<R: Runtime> WindowExt for Window<R> {
         width: state.width,
         height: state.height,
       }))?;
+
       let mut pos: Option<(i32, i32)> = None;
       for m in self.available_monitors()? {
         if m.name().map(ToString::to_string).unwrap_or_default() == state.monitor {


### PR DESCRIPTION
Switched order of `set_size` and `set_position`

Setting size after position can trigger a re-positionning of the window from the center if it has been resized since the start.
The issue has been experienced on MacOS, and this fix solves the issue