### PR TITLE
feat: add extra options to show window `Always/Auto/Never`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,7 +180,7 @@ impl Default for Builder {
 impl Builder {
   /// Whether to enable or disable automatically showing the window
   ///
-  /// - `Always`: the window will always be shown, regardless of what's the last store state was
+  /// - `Always`: the window will always be shown, regardless of what the last store state was
   /// - `Auto`: the window will be automatically shown if the last stored state for visibility was `true`
   /// - `Never`: the window will not be automatically shown by this plugin
   pub fn with_auto_show(mut self, auto_show: Show) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ pub enum Error {
 /// Defines how the window visibility should be restored.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum Show {
-  /// The window will always be shown, regardless of what's the last stored state was.
+  /// The window will always be shown, regardless of what the last stored state was.
   Always,
   /// The window will be automatically shown if the last stored state for visibility was `true`.
   Auto,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,12 @@ pub enum ShowMode {
   Never,
 }
 
+impl Default for ShowMode {
+  fn default() -> Self {
+    Self::LastSaved
+  }
+}
+
 pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Debug, Default, Deserialize, Serialize)]
@@ -174,7 +180,7 @@ pub struct Builder {
 impl Default for Builder {
   fn default() -> Self {
     Builder {
-      show_mode: ShowMode::LastSaved,
+      show_mode: Default::default(),
       denylist: Default::default(),
       skip_initial_state: Default::default(),
     }
@@ -183,6 +189,8 @@ impl Default for Builder {
 
 impl Builder {
   /// Sets how the window visibility should be restored.
+  ///
+  /// The default is [`ShowMode::LastSaved`]
   pub fn with_show_mode(mut self, show_mode: ShowMode) -> Self {
     self.show_mode = show_mode;
     self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,10 +29,14 @@ pub enum Error {
   Bincode(#[from] Box<bincode::ErrorKind>),
 }
 
+/// Defines how the window visibility should be restored.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum Show {
+  /// The window will always be shown, regardless of what's the last stored state was.
   Always,
+  /// The window will be automatically shown if the last stored state for visibility was `true`.
   Auto,
+  /// The window will not be automatically shown by this plugin.
   Never,
 }
 
@@ -178,18 +182,14 @@ impl Default for Builder {
 }
 
 impl Builder {
-  /// Whether to enable or disable automatically showing the window
-  ///
-  /// - `Always`: the window will always be shown, regardless of what the last store state was
-  /// - `Auto`: the window will be automatically shown if the last stored state for visibility was `true`
-  /// - `Never`: the window will not be automatically shown by this plugin
+  /// Sets how the window visibility should be restored.
   pub fn with_auto_show(mut self, auto_show: Show) -> Self {
     self.auto_show = auto_show;
     self
   }
 
   /// Sets a list of windows that shouldn't be tracked and managed by this plugin
-  /// for example splash screen widnows.
+  /// for example splash screen windows.
   pub fn with_denylist(mut self, denylist: &[&str]) -> Self {
     self.denylist = denylist.iter().map(|l| l.to_string()).collect();
     self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,20 +171,11 @@ impl<R: Runtime> WindowExt for Window<R> {
   }
 }
 
+#[derive(Default)]
 pub struct Builder {
   show_mode: ShowMode,
   denylist: HashSet<String>,
   skip_initial_state: HashSet<String>,
-}
-
-impl Default for Builder {
-  fn default() -> Self {
-    Builder {
-      show_mode: Default::default(),
-      denylist: Default::default(),
-      skip_initial_state: Default::default(),
-    }
-  }
 }
 
 impl Builder {


### PR DESCRIPTION
Closes tauri-apps/plugins-workspace#243 

Tested it locally and even if I force visible=false on the .window-state, if I set Show::Always, the app window will become visible when started